### PR TITLE
Revert "Fix ModuleNotFoundError in bayesian.py by adding missing __init__.py and correcting import paths"

### DIFF
--- a/metadpy/bayesian.py
+++ b/metadpy/bayesian.py
@@ -262,7 +262,7 @@ def hmetad(
 
         pymcData = extractParameters(np.asarray(nR_S1), np.asarray(nR_S2))
 
-        from metadpy.models.subject_level_pymc import hmetad_subjectLevel
+        from subject_level_pymc import hmetad_subjectLevel
 
         model_output = hmetad_subjectLevel(
             pymcData,
@@ -279,7 +279,7 @@ def hmetad(
             data, subject, stimuli, accuracy, confidence, nRatings
         )
 
-        from metadpy.models.group_level_pymc import hmetad_groupLevel
+        from group_level_pymc import hmetad_groupLevel
 
         model_output = hmetad_groupLevel(
             pymcData,

--- a/metadpy/models/__init__.py
+++ b/metadpy/models/__init__.py
@@ -1,1 +1,0 @@
-# Models package for metadpy


### PR DESCRIPTION
Reverts ddgpalmer/metadpy#2